### PR TITLE
[Minor][VIP-475] Made git package name managable

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -17,6 +17,9 @@
 # [*python_package*]
 #   Python package name, defaults to python
 #
+# [*git_package*]
+#   Git package name, defaults to git
+
 # == Example:
 #
 #  class { 'nodejs':
@@ -33,6 +36,7 @@ define nodejs::install (
   $target_dir     = undef,
   $make_install   = true,
   $python_package = 'python',
+  $git_package    = 'git',
 ) {
 
   include nodejs::params
@@ -62,8 +66,8 @@ define nodejs::install (
       ensure => installed
     }
   }
-  if !defined(Package['git']) {
-    package {'git':
+  if !defined(Package[$git_package]) {
+    package {$git_package:
       ensure => installed
     }
   }


### PR DESCRIPTION
### Overview

Added the ability to set the name of the git package dependency, so we are not forced to just use `git`. We do also want to be able to use `git2u`.

