### PR TITLE
[Minor][INC-346675] Get nodejs fact on windows

### DIFF
--- a/lib/facter/nodejs_installed_version.rb
+++ b/lib/facter/nodejs_installed_version.rb
@@ -1,5 +1,13 @@
 Facter.add("nodejs_installed_version") do
+  confine :kernel => "Linux"
   setcode do
     Facter::Util::Resolution.exec('node -v 2> /dev/null')
+  end
+end
+
+Facter.add("nodejs_installed_version") do
+  confine :kernel => "windows"
+  setcode do
+    Facter::Util::Resolution.exec('node -v 2> $null')
   end
 end


### PR DESCRIPTION
### Overview

Update nodejs_installed_version custom fact to run different commands on windows and linux

### Related issues

Ticket: https://support.bedegaming.com/a/tickets/346675
Fixes the 'The system cannot find the path specified' error during puppet runs on windows machines where node is installed